### PR TITLE
do not check for bits in the message type

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,7 +231,7 @@ class MessageType {
   }
 
   isImage () {
-    return (this.type & C.DC_MSG_IMAGE) === C.DC_MSG_IMAGE
+    return this.type === C.DC_MSG_IMAGE || this.type === C.DC_MSG_GIF
   }
 
   isGif () {
@@ -239,7 +239,7 @@ class MessageType {
   }
 
   isAudio () {
-    return (this.type & C.DC_MSG_AUDIO) === C.DC_MSG_AUDIO
+    return this.type === C.DC_MSG_AUDIO || this.type === C.DC_MSG_VOICE
   }
 
   isVoice () {
@@ -247,7 +247,7 @@ class MessageType {
   }
 
   isVideo () {
-    return (this.type & C.DC_MSG_VIDEO) === C.DC_MSG_VIDEO
+    return this.type === C.DC_MSG_VIDEO
   }
 
   isFile () {


### PR DESCRIPTION
the message type must be treated as integer, single bits currently do not have a special meaning.

for "overlapping" types as `DC_MSG_IMAGE`, `DC_MSG_GIF`, `DC_MSG_VIDEO` it depends a bit on the UI which whether "gif" is more an image or more a video. the core does not regulate this.

the PR, however, makes `isImage()` return TRUE on image+gif and `isAudio()` return TRUE on audio+voice messages - i think this was @ralphtheninja's intent. 
feel free to change this.

an alternative idea may be not to check for a combination of types but more for actions or controls needed for a set of types, eg. needsPlayButton() or so.