### PR TITLE
Build against system version of openssl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CC=gcc-7; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=g++-7; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig; fi
   - env
   - openssl version
   - ./scripts/travis-before-install
@@ -29,7 +30,7 @@ node_js:
   - 8
 
 install:
-  - npm install
+  - npm install --verbose
 
 before_script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then npm run start-test-server; else true; fi

--- a/binding.gyp
+++ b/binding.gyp
@@ -9,10 +9,9 @@
             "../deltachat-core/builddir/src/libdeltachat.a",
             "../deltachat-core/builddir/libs/libetpan/libetpan.a",
             "../deltachat-core/builddir/libs/cyrussasl/libsals2.a",
-            "../deltachat-core/builddir/libs/zlib-1.2.11/libz.a",
             "../deltachat-core/builddir/libs/netpgp/libnetpgp.a",
-            "../deltachat-core/builddir/libs/openssl/libcrypto.a",
-            "../deltachat-core/builddir/libs/sqlite/libsqlite.a",
+            "-lssl",
+            "-lsqlite3",
             "-lpthread"
           ]
         }]

--- a/scripts/rebuild-all.js
+++ b/scripts/rebuild-all.js
@@ -14,11 +14,9 @@ log(`>> Creating ${coreBuildDir}`)
 mkdirp.sync(coreBuildDir)
 
 const mesonOpts = { cwd: coreBuildDir }
+const mesonArgs = [ '--default-library=static' ]
 if (verbose) mesonOpts.stdio = 'inherit'
-spawn('meson', [
-  '--default-library=static',
-  '--wrap-mode=forcefallback'
-], mesonOpts)
+spawn('meson', mesonArgs, mesonOpts)
 
 spawn('ninja', verbose ? [ '-v' ] : [], {
   cwd: coreBuildDir,

--- a/scripts/travis-before-install
+++ b/scripts/travis-before-install
@@ -10,17 +10,11 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
    # Install meson
    sudo pip3 install meson
 
-   # Install ninja-build
+   # Install ninja
    wget https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip
    unzip ninja-linux.zip
    sudo cp ninja /usr/bin
+
 elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    # Upgrade pip
-    sudo -H pip3 install --upgrade pip
-
-    # Install meson
-    sudo -H pip3 install meson
-
-    # Install ninja
-    brew install ninja
+    brew install meson ninja
 fi


### PR DESCRIPTION
So, this PR undoes the `--wrap-mode=forcefallback` mode and tries to build against correct openssl on the system. Luckily for `linux`, the default version is `OpenSSL 1.0.1f 6 Jan 2014`, which seems to be binary compatible with `1.0.2` which is what the node 8 uses (which electron 2 is based on).

Closes https://github.com/deltachat/deltachat-node/issues/137