### PR TITLE
binding.gyp: Correct typo in libsals2 to libsasl2

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,7 +8,7 @@
           "libraries": [
             "../deltachat-core/builddir/src/libdeltachat.a",
             "../deltachat-core/builddir/libs/libetpan/libetpan.a",
-            "../deltachat-core/builddir/libs/cyrussasl/libsals2.a",
+            "../deltachat-core/builddir/libs/cyrussasl/libsasl2.a",
             "../deltachat-core/builddir/libs/netpgp/libnetpgp.a",
             "-lssl",
             "-lsqlite3",


### PR DESCRIPTION
That library, libsals2, does not exist yet. It should probably have been libsasl2.