### PR TITLE
[wip] Rethink libs again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - ./scripts/travis-before-install
 
 node_js:
-  - 8
+  - 8.9.3
 
 install:
   - npm install --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ addons:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CC=gcc-7; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=g++-7; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig; fi
   - env
   - openssl version
   - ./scripts/travis-before-install

--- a/binding.gyp
+++ b/binding.gyp
@@ -8,10 +8,9 @@
           "libraries": [
             "../deltachat-core/builddir/src/libdeltachat.a",
             "../deltachat-core/builddir/libs/libetpan/libetpan.a",
+            "../deltachat-core/builddir/libs/cyrussasl/libsals2.a",
             "../deltachat-core/builddir/libs/netpgp/libnetpgp.a",
-            "-lsasl2",
-            "-lssl",
-            "-lsqlite3",
+            "../deltachat-core/builddir/libs/sqlite/libsqlite.a",
             "-lpthread"
           ]
         }]

--- a/scripts/rebuild-all.js
+++ b/scripts/rebuild-all.js
@@ -14,7 +14,10 @@ log(`>> Creating ${coreBuildDir}`)
 mkdirp.sync(coreBuildDir)
 
 const mesonOpts = { cwd: coreBuildDir }
-const mesonArgs = [ '--default-library=static' ]
+const mesonArgs = [
+  '--default-library=static',
+  '--wrap-mode=forcefallback'
+]
 if (verbose) mesonOpts.stdio = 'inherit'
 spawn('meson', mesonArgs, mesonOpts)
 


### PR DESCRIPTION
I'm trying to get rid of linking to correct version of openssl. This works well if you're using node. But if you try to use it with electron we get `undefined symbol: CRYPTO_num_locks`. Not sure if this can be figured out or not, maybe someone has any ideas?

We know we can compile openssl in deltachat-core and link to _that_ version, but it makes the application super slow, even though it's the most stable solution.