### PR TITLE
[wip] Use all bundled libs from core

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,10 +8,11 @@
           "libraries": [
             "../deltachat-core/builddir/src/libdeltachat.a",
             "../deltachat-core/builddir/libs/libetpan/libetpan.a",
+            "../deltachat-core/builddir/libs/cyrussasl/libsals2.a",
+            "../deltachat-core/builddir/libs/zlib-1.2.11/libz.a",
             "../deltachat-core/builddir/libs/netpgp/libnetpgp.a",
-            "-lsasl2",
-            "-lssl",
-            "-lsqlite3",
+            "../deltachat-core/builddir/libs/openssl/libcrypto.a",
+            "../deltachat-core/builddir/libs/sqlite/libsqlite.a",
             "-lpthread"
           ]
         }]

--- a/scripts/rebuild-all.js
+++ b/scripts/rebuild-all.js
@@ -14,7 +14,10 @@ log(`>> Creating ${coreBuildDir}`)
 mkdirp.sync(coreBuildDir)
 
 const mesonOpts = { cwd: coreBuildDir }
-const mesonArgs = [ '--default-library=static' ]
+const mesonArgs = [
+  '--default-library=static',
+  '--wrap-mode=forcefallback'
+]
 if (verbose) mesonOpts.stdio = 'inherit'
 spawn('meson', mesonArgs, mesonOpts)
 


### PR DESCRIPTION
This goes back to using core with bundled libs. I personally think this is better because it's more stable. Key generation will be a lot slower but we are fixing this in core and once it's fixed it will propagate into all usages of core, including node bindings.

Since we're using `--wrap-mode=forcefallback` we will not have any problems with missing .a files due to globally installed dependencies.