### PR TITLE
Use version unchanged

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "coverage-html-report": "rm -rf coverage/ && nyc report --reporter=html && opn coverage/index.html",
-    "dependency-check": "dependency-check package.json --missing --unused -i dependency-check -i nyc -i opn-cli -i standard -i napi-macros -i coveralls --entry index.js --entry test/index.js --entry scripts/*.js",
+    "dependency-check": "dependency-check package.json --missing --unused -i dependency-check -i version-changed -i nyc -i opn-cli -i standard -i napi-macros -i coveralls --entry index.js --entry test/index.js --entry scripts/*.js",
     "generate-constants": "./scripts/generate-constants.js",
     "install": "node-gyp-build scripts/rebuild-core.js",
     "prebuild": "version-unchanged || node scripts/prebuildify.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dependency-check": "dependency-check package.json --missing --unused -i dependency-check -i nyc -i opn-cli -i standard -i napi-macros -i coveralls --entry index.js --entry test/index.js --entry scripts/*.js",
     "generate-constants": "./scripts/generate-constants.js",
     "install": "node-gyp-build scripts/rebuild-core.js",
-    "prebuild": "node scripts/prebuildify.js",
+    "prebuild": "version-unchanged || node scripts/prebuildify.js",
     "submodule": "git submodule update --recursive --init",
     "test": "standard && npm run dependency-check && nyc node test/index.js"
   },

--- a/scripts/prebuildify.js
+++ b/scripts/prebuildify.js
@@ -1,4 +1,3 @@
-const versionChanged = require('version-changed')
 const prebuildify = require('prebuildify')
 const path = require('path')
 const tar = require('tar')
@@ -6,17 +5,6 @@ const abi = require('node-abi')
 const gh = require('ghreleases')
 
 const pkg = require('../package.json')
-
-function main () {
-  versionChanged((err, changed) => {
-    if (err) exit(err)
-    if (!changed) {
-      console.log('Version hasn\'t changed. Skipping!')
-      process.exit(0)
-    }
-    build()
-  })
-}
 
 function build () {
   function onlyNode (t) {
@@ -90,4 +78,4 @@ function exit (err) {
   }
 }
 
-main()
+build()


### PR DESCRIPTION
This refactors `version-changed`, e.g. moving the code out to the cli tool instead.