### PR TITLE
README: sendTextMessage should be sendMessage in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ dc.open(() => {
   const onReady = () => {
     const contactId = dc.createContact('homie', 'friend@site.org')
     const chatId = dc.createChatByContactId(contactId)
-    dc.sendTextMessage(chatId, 'Hi!')
+    dc.sendMessage(chatId, 'Hi!')
   }
   if (!dc.isConfigured()) {
     dc.once('ready', onReady)


### PR DESCRIPTION
Besides that the example is wrong, it should be:

```
const C = require('deltachat-node/constants')
...
    const msg = this._dc.messageNew(C.DC_MSG_TEXT)
    msg.setText(text)
    dc.sendMessage(chatId, msg)
```

@Simon-Laux 