### PR TITLE
Add more debug statements

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -1,16 +1,19 @@
 /* eslint-disable camelcase */
 
 const binding = require('./binding')
+const debug = require('debug')('deltachat:chat')
 
 /**
  * Wrapper around dc_chat_t*
  */
 class Chat {
   constructor (dc_chat) {
+    debug('Chat constructor')
     this.dc_chat = dc_chat
   }
 
   toJson () {
+    debug('toJson')
     return {
       archived: this.getArchived(),
       color: this.getColor(),

--- a/chatlist.js
+++ b/chatlist.js
@@ -2,28 +2,34 @@
 
 const binding = require('./binding')
 const Lot = require('./lot')
+const debug = require('debug')('deltachat:chatlist')
 
 /**
  * Wrapper around dc_chatlist_t*
  */
 class ChatList {
   constructor (dc_chatlist) {
+    debug('ChatList constructor')
     this.dc_chatlist = dc_chatlist
   }
 
   getChatId (index) {
+    debug(`getChatId ${index}`)
     return binding.dcn_chatlist_get_chat_id(this.dc_chatlist, index)
   }
 
   getCount () {
+    debug('getCount')
     return binding.dcn_chatlist_get_cnt(this.dc_chatlist)
   }
 
   getMessageId (index) {
+    debug(`getMessageId ${index}`)
     return binding.dcn_chatlist_get_msg_id(this.dc_chatlist, index)
   }
 
   getSummary (index, chat) {
+    debug(`getSummary ${index}`)
     const dc_chat = (chat && chat.dc_chat) || null
     return new Lot(
       binding.dcn_chatlist_get_summary(

--- a/contact.js
+++ b/contact.js
@@ -1,16 +1,19 @@
 /* eslint-disable camelcase */
 
 const binding = require('./binding')
+const debug = require('debug')('deltachat:contact')
 
 /**
  * Wrapper around dc_contact_t*
  */
 class Contact {
   constructor (dc_contact) {
+    debug('Contact constructor')
     this.dc_contact = dc_contact
   }
 
   toJson () {
+    debug('toJson')
     return {
       address: this.getAddress(),
       color: this.getColor(),

--- a/index.js
+++ b/index.js
@@ -13,13 +13,14 @@ const mkdirp = require('mkdirp')
 const path = require('path')
 const got = require('got')
 const pick = require('lodash.pick')
-const debug = require('debug')('deltachat')
+const debug = require('debug')('deltachat:index')
 
 /**
  * Wrapper around dcn_context_t*
  */
 class DeltaChat extends EventEmitter {
   constructor () {
+    debug('DeltaChat constructor')
     super()
 
     this._pollInterval = null
@@ -31,10 +32,12 @@ class DeltaChat extends EventEmitter {
   }
 
   addAddressBook (addressBook) {
+    debug(`addAddressBook ${addressBook}`)
     return binding.dcn_add_address_book(this.dcn_context, addressBook)
   }
 
   addContactToChat (chatId, contactId) {
+    debug(`addContactToChat ${chatId} ${contactId}`)
     return Boolean(
       binding.dcn_add_contact_to_chat(
         this.dcn_context,
@@ -45,6 +48,7 @@ class DeltaChat extends EventEmitter {
   }
 
   archiveChat (chatId, archive) {
+    debug(`archiveChat ${chatId} ${archive}`)
     binding.dcn_archive_chat(
       this.dcn_context,
       Number(chatId),
@@ -53,6 +57,7 @@ class DeltaChat extends EventEmitter {
   }
 
   blockContact (contactId, block) {
+    debug(`blockContact ${contactId} ${block}`)
     binding.dcn_block_contact(
       this.dcn_context,
       Number(contactId),
@@ -61,19 +66,23 @@ class DeltaChat extends EventEmitter {
   }
 
   checkPassword (password) {
+    debug('checkPassword')
     return Boolean(binding.dcn_check_password(this.dcn_context, password))
   }
 
   checkQrCode (qrCode) {
+    debug(`checkQrCode ${qrCode}`)
     const dc_lot = binding.dcn_check_qr(this.dcn_context, qrCode)
     return dc_lot ? new Lot(dc_lot) : null
   }
 
   clearStringTable () {
+    debug('clearStringTable')
     binding.dcn_clear_string_table(this.dcn_context)
   }
 
   close () {
+    debug('close')
     this.removeAllListeners()
 
     // TODO temporary polling interval
@@ -88,6 +97,7 @@ class DeltaChat extends EventEmitter {
   }
 
   configure (opts, cb) {
+    debug('configure')
     if (!opts) opts = {}
     const ready = () => {
       this.emit('ready')
@@ -135,6 +145,7 @@ class DeltaChat extends EventEmitter {
   }
 
   continueKeyTransfer (messageId, setupCode, cb) {
+    debug(`continueKeyTransfer ${messageId}`)
     binding.dcn_continue_key_transfer(this.dcn_context, Number(messageId), setupCode, result => {
       if (result === 0) {
         return cb(new Error('Key transfer failed due to bad setup code'))
@@ -144,6 +155,7 @@ class DeltaChat extends EventEmitter {
   }
 
   createChatByContactId (contactId) {
+    debug(`createChatByContactId ${contactId}`)
     return binding.dcn_create_chat_by_contact_id(
       this.dcn_context,
       Number(contactId)
@@ -151,6 +163,7 @@ class DeltaChat extends EventEmitter {
   }
 
   createChatByMessageId (messageId) {
+    debug(`createChatByMessageId ${messageId}`)
     return binding.dcn_create_chat_by_msg_id(
       this.dcn_context,
       Number(messageId)
@@ -158,22 +171,27 @@ class DeltaChat extends EventEmitter {
   }
 
   createContact (name, addr) {
+    debug(`createContact ${name} ${addr}`)
     return binding.dcn_create_contact(this.dcn_context, name, addr)
   }
 
   createUnverifiedGroupChat (chatName) {
+    debug(`createUnverifiedGroupChat ${chatName}`)
     return binding.dcn_create_group_chat(this.dcn_context, 0, chatName)
   }
 
   createVerifiedGroupChat (chatName) {
+    debug(`createVerifiedGroupChat ${chatName}`)
     return binding.dcn_create_group_chat(this.dcn_context, 1, chatName)
   }
 
   deleteChat (chatId) {
+    debug(`deleteChat ${chatId}`)
     binding.dcn_delete_chat(this.dcn_context, Number(chatId))
   }
 
   deleteContact (contactId) {
+    debug(`deleteContact ${contactId}`)
     return Boolean(
       binding.dcn_delete_contact(
         this.dcn_context,
@@ -187,6 +205,7 @@ class DeltaChat extends EventEmitter {
       messageIds = [ messageIds ]
     }
     messageIds = messageIds.map(id => Number(id))
+    debug('deleteMessages', messageIds)
     binding.dcn_delete_msgs(this.dcn_context, messageIds)
   }
 
@@ -195,35 +214,43 @@ class DeltaChat extends EventEmitter {
       messageIds = [ messageIds ]
     }
     messageIds = messageIds.map(id => Number(id))
+    debug('forwardMessages', messageIds)
     binding.dcn_forward_msgs(this.dcn_context, messageIds, chatId)
   }
 
   getBlobdir () {
+    debug('getBlobdir')
     return binding.dcn_get_blobdir(this.dcn_context)
   }
 
   getBlockedCount () {
+    debug('getBlockedCount')
     return binding.dcn_get_blocked_cnt(this.dcn_context)
   }
 
   getBlockedContacts () {
+    debug('getBlockedContacts')
     return binding.dcn_get_blocked_contacts(this.dcn_context)
   }
 
   getChat (chatId) {
+    debug(`getChat ${chatId}`)
     const dc_chat = binding.dcn_get_chat(this.dcn_context, Number(chatId))
     return dc_chat ? new Chat(dc_chat) : null
   }
 
   getChatContacts (chatId) {
+    debug(`getChatContacts ${chatId}`)
     return binding.dcn_get_chat_contacts(this.dcn_context, Number(chatId))
   }
 
   getChatIdByContactId (contactId) {
+    debug(`getChatIdByContactId ${contactId}`)
     return binding.dcn_get_chat_id_by_contact_id(this.dcn_context, Number(contactId))
   }
 
   getChatMedia (chatId, msgType1, msgType2, msgType3) {
+    debug(`getChatMedia ${chatId}`)
     return binding.dcn_get_chat_media(
       this.dcn_context,
       Number(chatId),
@@ -234,10 +261,12 @@ class DeltaChat extends EventEmitter {
   }
 
   getMimeHeaders (messageId) {
+    debug(`getMimeHeaders ${messageId}`)
     return binding.dcn_get_mime_headers(this.dcn_context, Number(messageId))
   }
 
   getChatMessages (chatId, flags, marker1before) {
+    debug(`getChatMessages ${chatId} ${flags} ${marker1before}`)
     return binding.dcn_get_chat_msgs(
       this.dcn_context,
       Number(chatId),
@@ -247,6 +276,7 @@ class DeltaChat extends EventEmitter {
   }
 
   getChats (listFlags, queryStr, queryContactId) {
+    debug('getChats')
     const result = []
     const list = this.getChatList(listFlags, queryStr, queryContactId)
     const count = list.getCount()
@@ -260,6 +290,7 @@ class DeltaChat extends EventEmitter {
     listFlags = listFlags || 0
     queryStr = queryStr || ''
     queryContactId = queryContactId || 0
+    debug(`getChatList ${listFlags} ${queryStr} ${queryContactId}`)
     return new ChatList(
       binding.dcn_get_chatlist(
         this.dcn_context,
@@ -271,6 +302,7 @@ class DeltaChat extends EventEmitter {
   }
 
   static getConfig (dir, cb) {
+    debug(`DeltaChat.getConfig ${dir}`)
     let dc = new DeltaChat()
     function done (err, config) {
       dc = null
@@ -288,10 +320,12 @@ class DeltaChat extends EventEmitter {
   }
 
   getConfig (key) {
+    debug(`getConfig ${key}`)
     return binding.dcn_get_config(this.dcn_context, key)
   }
 
   getContact (contactId) {
+    debug(`getContact ${contactId}`)
     const dc_contact = binding.dcn_get_contact(
       this.dcn_context,
       Number(contactId)
@@ -300,29 +334,35 @@ class DeltaChat extends EventEmitter {
   }
 
   getContactEncryptionInfo (contactId) {
+    debug(`getContactEncryptionInfo ${contactId}`)
     return binding.dcn_get_contact_encrinfo(this.dcn_context, Number(contactId))
   }
 
   getContacts (listFlags, query) {
     listFlags = listFlags || 0
     query = query || ''
+    debug(`getContacts ${listFlags} ${query}`)
     return binding.dcn_get_contacts(this.dcn_context, listFlags, query)
   }
 
   getDraft (chatId) {
+    debug(`getDraft ${chatId}`)
     const dc_msg = binding.dcn_get_draft(this.dcn_context, Number(chatId))
     return dc_msg ? new Message(dc_msg) : null
   }
 
   getFreshMessageCount (chatId) {
+    debug(`getFreshMessageCount ${chatId}`)
     return binding.dcn_get_fresh_msg_cnt(this.dcn_context, Number(chatId))
   }
 
   getFreshMessages () {
+    debug('getFreshMessages')
     return binding.dcn_get_fresh_msgs(this.dcn_context)
   }
 
   getInfo () {
+    debug('getInfo')
     const result = {}
 
     const regex = /^(\w+)=(.*)$/i
@@ -340,19 +380,23 @@ class DeltaChat extends EventEmitter {
   }
 
   getMessage (messageId) {
+    debug(`getMessage ${messageId}`)
     const dc_msg = binding.dcn_get_msg(this.dcn_context, Number(messageId))
     return dc_msg ? new Message(dc_msg) : null
   }
 
   getMessageCount (chatId) {
+    debug(`getMessageCount ${chatId}`)
     return binding.dcn_get_msg_cnt(this.dcn_context, Number(chatId))
   }
 
   getMessageInfo (messageId) {
+    debug(`getMessageInfo ${messageId}`)
     return binding.dcn_get_msg_info(this.dcn_context, Number(messageId))
   }
 
   getNextMediaMessage (messageId, msgType1, msgType2, msgType3) {
+    debug(`getNextMediaMessage ${messageId} ${msgType1} ${msgType2} ${msgType3}`)
     return this._getNextMedia(
       messageId,
       1,
@@ -363,6 +407,7 @@ class DeltaChat extends EventEmitter {
   }
 
   getPreviousMediaMessage (messageId, msgType1, msgType2, msgType3) {
+    debug(`getPreviousMediaMessage ${messageId} ${msgType1} ${msgType2} ${msgType3}`)
     return this._getNextMedia(
       messageId,
       -1,
@@ -383,15 +428,18 @@ class DeltaChat extends EventEmitter {
     )
   }
 
-  getSecurejoinQrCode (groupChatId) {
-    return binding.dcn_get_securejoin_qr(this.dcn_context, Number(groupChatId))
+  getSecurejoinQrCode (chatId) {
+    debug(`getSecurejoinQrCode ${chatId}`)
+    return binding.dcn_get_securejoin_qr(this.dcn_context, Number(chatId))
   }
 
   getStarredMessages () {
+    debug('getStarredMessages')
     return this.getChatMessages(C.DC_CHAT_ID_STARRED, 0, 0)
   }
 
   static getSystemInfo () {
+    debug('DeltaChat.getSystemInfo')
     let dc = new DeltaChat()
     const result = pick(dc.getInfo(), [
       'deltachat_core_version',
@@ -407,14 +455,17 @@ class DeltaChat extends EventEmitter {
   }
 
   importExport (what, param1, param2) {
+    debug(`importExport ${what} ${param1} ${param2}`)
     binding.dcn_imex(this.dcn_context, what, param1, param2 || '')
   }
 
-  importExportHasBackup (dirName) {
-    return binding.dcn_imex_has_backup(this.dcn_context, dirName)
+  importExportHasBackup (dir) {
+    debug(`importExportHasBackup ${dir}`)
+    return binding.dcn_imex_has_backup(this.dcn_context, dir)
   }
 
   initiateKeyTransfer (cb) {
+    debug('initiateKeyTransfer')
     return binding.dcn_initiate_key_transfer(this.dcn_context, statusCode => {
       if (typeof statusCode === 'string') {
         return cb(null, statusCode)
@@ -424,10 +475,12 @@ class DeltaChat extends EventEmitter {
   }
 
   isConfigured () {
+    debug('isConfigured')
     return Boolean(binding.dcn_is_configured(this.dcn_context))
   }
 
   isContactInChat (chatId, contactId) {
+    debug(`isContactInChat ${chatId} ${contactId}`)
     return Boolean(
       binding.dcn_is_contact_in_chat(
         this.dcn_context,
@@ -438,30 +491,36 @@ class DeltaChat extends EventEmitter {
   }
 
   isOpen () {
+    debug('isOpen')
     return Boolean(binding.dcn_is_open(this.dcn_context))
   }
 
   // TODO this should most likely be async, see
   // https://c.delta.chat/classdc__context__t.html#ae49176cbc26d4d40d52de4f5301d1fa7
   joinSecurejoin (qrCode) {
+    debug(`joinSecurejoin ${qrCode}`)
     return binding.dcn_join_securejoin(this.dcn_context, qrCode)
   }
 
   lookupContactIdByAddr (addr) {
+    debug(`lookupContactIdByAddr ${addr}`)
     return Boolean(
       binding.dcn_lookup_contact_id_by_addr(this.dcn_context, addr)
     )
   }
 
   markNoticedChat (chatId) {
+    debug(`markNoticedChat ${chatId}`)
     binding.dcn_marknoticed_chat(this.dcn_context, Number(chatId))
   }
 
   markNoticedAllChats () {
+    debug('markNoticedAllChats')
     binding.dcn_marknoticed_all_chats(this.dcn_context)
   }
 
   markNoticedContact (contactId) {
+    debug(`markNoticedContact ${contactId}`)
     binding.dcn_marknoticed_contact(this.dcn_context, Number(contactId))
   }
 
@@ -470,23 +529,28 @@ class DeltaChat extends EventEmitter {
       messageIds = [ messageIds ]
     }
     messageIds = messageIds.map(id => Number(id))
+    debug('markSeenMessages', messageIds)
     binding.dcn_markseen_msgs(this.dcn_context, messageIds)
   }
 
   static maybeValidAddr (addr) {
+    debug('DeltaChat.maybeValidAddr')
     if (addr === null) return false
     return Boolean(binding.dcn_maybe_valid_addr(addr))
   }
 
   maybeNetwork () {
+    debug('maybeNetwork')
     binding.dcn_maybe_network(this.dcn_context)
   }
 
   messageNew (viewType = C.DC_MSG_TEXT) {
+    debug(`messageNew ${viewType}`)
     return new Message(binding.dcn_msg_new(this.dcn_context, viewType))
   }
 
   open (cwd, cb) {
+    debug(`open ${cwd}`)
     if (typeof cwd === 'function') {
       cb = cwd
       cwd = process.cwd()
@@ -499,7 +563,6 @@ class DeltaChat extends EventEmitter {
       const db = path.join(cwd, 'db.sqlite')
       binding.dcn_open(this.dcn_context, db, '', err => {
         if (err) return cb(err)
-
         binding.dcn_start_threads(this.dcn_context)
 
         // TODO temporary timer for polling events
@@ -516,6 +579,7 @@ class DeltaChat extends EventEmitter {
   }
 
   removeContactFromChat (chatId, contactId) {
+    debug(`removeContactFromChat ${chatId} ${contactId}`)
     return Boolean(
       binding.dcn_remove_contact_from_chat(
         this.dcn_context,
@@ -526,10 +590,12 @@ class DeltaChat extends EventEmitter {
   }
 
   searchMessages (chatId, query) {
+    debug(`searchMessages ${chatId} ${query}`)
     return binding.dcn_search_msgs(this.dcn_context, Number(chatId), query)
   }
 
   sendMessage (chatId, msg) {
+    debug(`sendMessage ${chatId}`)
     if (!msg) {
       throw new Error('invalid msg parameter')
     }
@@ -545,6 +611,7 @@ class DeltaChat extends EventEmitter {
   }
 
   setChatName (chatId, name) {
+    debug(`setChatName ${chatId} ${name}`)
     return Boolean(
       binding.dcn_set_chat_name(
         this.dcn_context,
@@ -555,6 +622,7 @@ class DeltaChat extends EventEmitter {
   }
 
   setChatProfileImage (chatId, image) {
+    debug(`setChatProfileImage ${chatId} ${image}`)
     return Boolean(
       binding.dcn_set_chat_profile_image(
         this.dcn_context,
@@ -565,10 +633,12 @@ class DeltaChat extends EventEmitter {
   }
 
   setConfig (key, value) {
+    debug(`setConfig ${key} ${value}`)
     return binding.dcn_set_config(this.dcn_context, key, value || '')
   }
 
   setDraft (chatId, msg) {
+    debug(`setDraft ${chatId}`)
     binding.dcn_set_draft(
       this.dcn_context,
       Number(chatId),
@@ -577,6 +647,7 @@ class DeltaChat extends EventEmitter {
   }
 
   setStringTable (index, str) {
+    debug(`setStringTable ${index} ${str}`)
     binding.dcn_set_string_table(this.dcn_context, Number(index), str)
   }
 
@@ -585,6 +656,7 @@ class DeltaChat extends EventEmitter {
       messageIds = [ messageIds ]
     }
     messageIds = messageIds.map(id => Number(id))
+    debug('starMessages', messageIds)
     binding.dcn_star_msgs(this.dcn_context, messageIds, star ? 1 : 0)
   }
 }
@@ -598,7 +670,7 @@ function handleEvent (self, event, data1, data2) {
 
   async function handleHttpGetEvent (url) {
     try {
-      debug('handleHttpGetEvent url', url)
+      debug(`handleHttpGetEvent ${url}`)
       const response = await got(url, {})
       debug('handleHttpGetEvent response.body', response.body)
       binding.dcn_set_http_get_response(self.dcn_context, response.body)

--- a/lot.js
+++ b/lot.js
@@ -1,16 +1,19 @@
 /* eslint-disable camelcase */
 
 const binding = require('./binding')
+const debug = require('debug')('deltachat:lot')
 
 /**
  * Wrapper around dc_lot_t*
  */
 class Lot {
   constructor (dc_lot) {
+    debug('Lot constructor')
     this.dc_lot = dc_lot
   }
 
   toJson () {
+    debug('toJson')
     return {
       state: this.getState(),
       text1: this.getText1(),

--- a/message.js
+++ b/message.js
@@ -3,6 +3,7 @@
 const binding = require('./binding')
 const C = require('./constants')
 const Lot = require('./lot')
+const debug = require('debug')('deltachat:message')
 
 /**
  * Helper class for message states so you can do e.g.
@@ -12,6 +13,7 @@ const Lot = require('./lot')
  */
 class MessageState {
   constructor (state) {
+    debug(`MessageState constructor ${state}`)
     this.state = state
   }
 
@@ -56,6 +58,7 @@ class MessageState {
  */
 class MessageViewType {
   constructor (viewType) {
+    debug(`MessageViewType constructor ${viewType}`)
     this.viewType = viewType
   }
 
@@ -93,10 +96,12 @@ class MessageViewType {
  */
 class Message {
   constructor (dc_msg) {
+    debug('Message constructor')
     this.dc_msg = dc_msg
   }
 
   toJson () {
+    debug('toJson')
     return {
       chatId: this.getChatId(),
       duration: this.getDuration(),


### PR DESCRIPTION
You can enable all deltachat related debug statements by doing `DEBUG=deltachat*` or limit it to certain files like `DEBUG=deltachat:message`.

Also useful in desktop, so you can do e.g. `DEBUG=deltachat* npx electron .`