### PR TITLE
Tweak preinstall script for node-gyp-build to work on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "coverage-html-report": "rm -rf coverage/ && nyc report --reporter=html && opn coverage/index.html",
     "generate-constants": "./scripts/generate-constants.js",
-    "install": "node-gyp-build scripts/rebuild-core.js",
+    "install": "node-gyp-build \"node scripts/rebuild-core.js\"",
     "prebuild": "node scripts/prebuildify.js",
     "submodule": "git submodule update --recursive --init",
     "test": "standard && nyc node test/index.js",

--- a/scripts/rebuild-core.js
+++ b/scripts/rebuild-core.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 const path = require('path')
 const rimraf = require('rimraf')
 const mkdirp = require('mkdirp')


### PR DESCRIPTION
Fixes the part in https://github.com/deltachat/deltachat-node/issues/243 related to preinstall script on windows