### PR TITLE
Adding gnu99 cstd for CentOS 7 build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -13,6 +13,9 @@
             "-lssl",
             "-lsqlite3",
             "-lpthread"
+          ],
+          "cflags": [
+            "-std=gnu99"
           ]
         }],
         [ "OS == 'mac'", {


### PR DESCRIPTION
Been getting C99 compatibility errors from GCC when building for CentOS7.  Adding the `cflag` for `gnu99` to the gyp bindings fixes this.

```[cpaul@localhost deltachat-node]$ npm install

> deltachat-node@0.40.2 install /home/cpaul/mailman-pgp/deltachat-node
> node-gyp-build scripts/rebuild-core.js

[165/165] Linking target cmdline/delta.
make: Entering directory `/home/cpaul/mailman-pgp/deltachat-node/build'
  CC(target) Release/obj.target/deltachat/src/module.o
../src/module.c: In function ‘js_array_to_uint32’:
../src/module.c:310:3: error: ‘for’ loop initial declarations are only allowed in C99 mode
   for (uint32_t i = 0; i < *length; i++) {
   ^
../src/module.c:310:3: note: use option -std=c99 or -std=gnu99 to compile your code
../src/module.c: In function ‘dc_array_to_js_array’:
../src/module.c:326:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (int i = 0; i < length; i++) {
     ^
make: *** [Release/obj.target/deltachat/src/module.o] Error 1
make: Leaving directory `/home/cpaul/mailman-pgp/deltachat-node/build'
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/home/cpaul/.nvm/versions/node/v11.9.0/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:262:23)
gyp ERR! stack     at ChildProcess.emit (events.js:197:13)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:254:12)
gyp ERR! System Linux 3.10.0-957.5.1.el7.x86_64
gyp ERR! command "/home/cpaul/.nvm/versions/node/v11.9.0/bin/node" "/home/cpaul/.nvm/versions/node/v11.9.0/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /home/cpaul/mailman-pgp/deltachat-node
gyp ERR! node -v v11.9.0
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! deltachat-node@0.40.2 install: `node-gyp-build scripts/rebuild-core.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the deltachat-node@0.40.2 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/cpaul/.npm/_logs/2019-02-16T04_45_30_378Z-debug.log
```