### PR TITLE
Catch unhandled error

### DIFF
--- a/index.js
+++ b/index.js
@@ -572,7 +572,7 @@ class DeltaChat extends EventEmitter {
             if (event) {
               handleEvent(this, event.event, event.data1, event.data2)
             }
-          } catch(err) {
+          } catch (err) {
             debug(`dcn_poll_event error ${err}`)
           }
         }, 50)

--- a/index.js
+++ b/index.js
@@ -567,9 +567,13 @@ class DeltaChat extends EventEmitter {
 
         // TODO temporary timer for polling events
         this._pollInterval = setInterval(() => {
-          const event = binding.dcn_poll_event(this.dcn_context)
-          if (event) {
-            handleEvent(this, event.event, event.data1, event.data2)
+          try {
+            const event = binding.dcn_poll_event(this.dcn_context)
+            if (event) {
+              handleEvent(this, event.event, event.data1, event.data2)
+            }
+          } catch(err) {
+            debug(`dcn_poll_event error ${err}`)
           }
         }, 50)
 


### PR DESCRIPTION
Wrong credentials for IMAP causes UNHANDLED_ERROR
`{ Error [ERR_UNHANDLED_ERROR]: Unhandled error. (Login as "uh3jbynm5f75jieu@ethereal.email" not possible. Answer imap.ethereal.email: Invalid credentials`
Happens in deltachat-desktop when updating credentials with wrong password or mailServer
see [deltachat/deltachat-desktop#695](https://github.com/deltachat/deltachat-desktop/pull/695)