### PR TITLE
Skip integration tests for PR from forked repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ node_js:
 
 script:
   - npm test
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run test-integration fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run test-integration; fi'
 
 before_deploy:
   - export ARCHIVE_NAME="${TRAVIS_TAG:-latest}-darwin-x64.tar.gz"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ node_js:
 
 script:
   - npm test
-  - npm run test-integration
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run test-integration fi'
   - npm run prebuild
 
 notifications:


### PR DESCRIPTION
since integration tests use encrypted variables
and these are not allowed in travis we have to
skip the tests (until we find a better solution
to run these tests againt a local dokcer mailserver
for example)

see https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions

fixes #251