### PR TITLE
fix: dc.close() is async

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ dc.open(() => {
     const contactId = dc.createContact('Test', contact)
     const chatId = dc.createChatByContactId(contactId)
     dc.sendMessage(chatId, 'Hi!')
+    dc.close(() => {
+      console.log('Bye.')
+    })
   }
   if (!dc.isConfigured()) {
     dc.once('ready', onReady)
@@ -176,9 +179,9 @@ Check a scanned QR code. Corresponds to [`dc_check_qr()`](https://c.delta.chat/c
 
 Clears the string table for handling `DC_EVENT_GET_STR` events from core.
 
-#### `dc.close()`
+#### `dc.close([cb])`
 
-Stops the threads and closes down the `DeltaChat` instance.
+Stops the threads and closes down the `DeltaChat` instance. Calls back when underlying context has been fully closed.
 
 #### `dc.configure(options[, cb])`
 

--- a/lib/deltachat.js
+++ b/lib/deltachat.js
@@ -16,6 +16,8 @@ const Locations = require('./locations')
 const pick = require('lodash.pick')
 const debug = require('debug')('deltachat:node:index')
 
+const noop = function () {}
+
 /**
  * Wrapper around dcn_context_t*
  */
@@ -80,12 +82,10 @@ class DeltaChat extends EventEmitter {
     binding.dcn_clear_string_table(this.dcn_context)
   }
 
-  close () {
+  close (cb = noop) {
     debug('close')
     this.removeAllListeners()
-
-    binding.dcn_unset_event_handler(this.dcn_context)
-    binding.dcn_stop_threads(this.dcn_context)
+    binding.dcn_close(this.dcn_context, cb)
   }
 
   configure (opts, cb) {
@@ -297,13 +297,19 @@ class DeltaChat extends EventEmitter {
     debug(`DeltaChat.getConfig ${dir}`)
     const dcn_context = binding.dcn_context_new()
     const db = dir.endsWith('db.sqlite') ? dir : path.join(dir, 'db.sqlite')
+    const done = (err, result) => {
+      binding.dcn_close(dcn_context, () => {
+        debug(`closed context for getConfig ${dir}`)
+      })
+      cb(err, result)
+    }
     binding.dcn_open(dcn_context, db, '', err => {
-      if (err) return cb(err)
+      if (err) return done(err)
       if (binding.dcn_is_configured(dcn_context)) {
         const addr = binding.dcn_get_config(dcn_context, 'addr')
-        return cb(null, { addr })
+        return done(null, { addr })
       }
-      cb(null, {})
+      done(null, {})
     })
   }
 
@@ -351,10 +357,15 @@ class DeltaChat extends EventEmitter {
 
   getInfo () {
     debug('getInfo')
+    return DeltaChat._getInfo(this.dcn_context)
+  }
+
+  static _getInfo (dcn_context) {
+    debug('static _getInfo')
     const result = {}
 
     const regex = /^(\w+)=(.*)$/i
-    binding.dcn_get_info(this.dcn_context)
+    binding.dcn_get_info(dcn_context)
       .split('\n')
       .filter(Boolean)
       .forEach(line => {
@@ -428,8 +439,9 @@ class DeltaChat extends EventEmitter {
 
   static getSystemInfo () {
     debug('DeltaChat.getSystemInfo')
-    let dc = new DeltaChat()
-    const result = pick(dc.getInfo(), [
+    const dcn_context = binding.dcn_context_new()
+    const info = DeltaChat._getInfo(dcn_context)
+    const result = pick(info, [
       'deltachat_core_version',
       'sqlite_version',
       'sqlite_thread_safe',
@@ -438,8 +450,9 @@ class DeltaChat extends EventEmitter {
       'compile_date',
       'arch'
     ])
-    dc.close()
-    dc = null
+    binding.dcn_close(dcn_context, () => {
+      debug('closed context for getSystemInfo')
+    })
     return result
   }
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -133,7 +133,9 @@ test('initiate key transfer', t => {
 })
 
 test('tearDown dc context', t => {
-  // TODO dc.close() should callback
-  dc.close()
-  t.end()
+  console.time('dc.close')
+  dc.close(() => {
+    console.timeEnd('dc.close')
+    t.end()
+  })
 })


### PR DESCRIPTION
Closes #80 
Closes #321 

This should prevent desktop from hanging in the ui thread during garbage collection.

Note that the integration tests will still hang until the threads have been stopped in `dc-rs`. There's no way around this unless we do a `setTimeout()` and `process.exit(0)`.