### PR TITLE
fix(windows): use mutex from libuv for the string table

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,6 +10,7 @@
         "target_name": "deltachat",
         "sources": [
             "./src/module.c",
+            "./src/strtable.c",
         ],
         "include_dirs": [
             "<!(node -e \"require('napi-macros')\")",

--- a/src/module.c
+++ b/src/module.c
@@ -8,8 +8,7 @@
 #include <uv.h>
 #include <deltachat-ffi/deltachat.h>
 #include "napi-macros-extensions.h"
-// TODO remove
-//#include "strtable.h"
+#include "strtable.h"
 
 #ifdef DEBUG
 #define TRACE(fmt, ...) fprintf(stderr, "> module.c:%d %s() " fmt "\n", __LINE__, __func__, ##__VA_ARGS__)
@@ -28,8 +27,7 @@ int dc_msg_has_deviating_timestamp(const dc_msg_t*);
 typedef struct dcn_context_t {
   dc_context_t* dc_context;
   napi_threadsafe_function threadsafe_event_handler;
-  // TODO remove
-  //strtable_t* strtable;
+  strtable_t* strtable;
   uv_thread_t imap_thread;
   uv_thread_t smtp_thread;
   uv_thread_t mvbox_thread;
@@ -65,10 +63,7 @@ static uintptr_t dc_event_handler(dc_context_t* dc_context, int event, uintptr_t
   }
 
   if (event == DC_EVENT_GET_STRING) {
-    // TODO handle this in core
-    // TODO remove
-    //return (uintptr_t)strtable_get_str(dcn_context->strtable, (int)data1);
-    return 0;
+    return (uintptr_t)strtable_get_str(dcn_context->strtable, (int)data1);
   }
 
   // Start tracing events here. DC_EVENT_GET_STRING is just too spammy.
@@ -326,8 +321,7 @@ NAPI_METHOD(dcn_context_new) {
   dcn_context_t* dcn_context = calloc(1, sizeof(dcn_context_t));
   dcn_context->dc_context = dc_context_new(dc_event_handler, dcn_context, NULL);
   dcn_context->threadsafe_event_handler = NULL;
-  // TODO remove
-  //dcn_context->strtable = strtable_new();
+  dcn_context->strtable = strtable_new();
 
   dcn_context->imap_thread = 0;
   dcn_context->smtp_thread = 0;
@@ -441,14 +435,12 @@ NAPI_METHOD(dcn_check_qr) {
   return result;
 }
 
-// TODO remove this function
 NAPI_METHOD(dcn_clear_string_table) {
   NAPI_ARGV(1);
   NAPI_DCN_CONTEXT();
 
   //TRACE("calling..");
-  // TODO remove
-  //strtable_clear(dcn_context->strtable);
+  strtable_clear(dcn_context->strtable);
   //TRACE("done");
 
   NAPI_RETURN_UNDEFINED();
@@ -512,10 +504,9 @@ static void dcn_close_execute(napi_env env, void* data) {
   dc_context_unref(dcn_context->dc_context);
   dcn_context->dc_context = NULL;
 
-  // TODO remove
-  //TRACE("cleaning up string table");
-  //strtable_unref(dcn_context->strtable);
-  //dcn_context->strtable = NULL;
+  TRACE("cleaning up string table");
+  strtable_unref(dcn_context->strtable);
+  dcn_context->strtable = NULL;
 
   TRACE("freeing dcn_context");
   free(dcn_context);
@@ -1544,7 +1535,6 @@ NAPI_METHOD(dcn_set_event_handler) {
   NAPI_RETURN_UNDEFINED();
 }
 
-// TODO remove this function
 NAPI_METHOD(dcn_set_string_table) {
   NAPI_ARGV(3);
   NAPI_DCN_CONTEXT();
@@ -1552,8 +1542,7 @@ NAPI_METHOD(dcn_set_string_table) {
   NAPI_ARGV_UTF8_MALLOC(str, 2);
 
   //TRACE("calling..");
-  // TODO remove
-  //strtable_set_str(dcn_context->strtable, index, str);
+  strtable_set_str(dcn_context->strtable, index, str);
   //TRACE("done");
 
   free(str);
@@ -2614,7 +2603,6 @@ NAPI_INIT() {
   NAPI_EXPORT_FUNCTION(dcn_archive_chat);
   NAPI_EXPORT_FUNCTION(dcn_block_contact);
   NAPI_EXPORT_FUNCTION(dcn_check_qr);
-  // TODO remove
   NAPI_EXPORT_FUNCTION(dcn_clear_string_table);
   NAPI_EXPORT_FUNCTION(dcn_close);
   NAPI_EXPORT_FUNCTION(dcn_configure);
@@ -2673,7 +2661,6 @@ NAPI_INIT() {
   NAPI_EXPORT_FUNCTION(dcn_set_config);
   NAPI_EXPORT_FUNCTION(dcn_set_draft);
   NAPI_EXPORT_FUNCTION(dcn_set_event_handler);
-  // TODO remove
   NAPI_EXPORT_FUNCTION(dcn_set_string_table);
   NAPI_EXPORT_FUNCTION(dcn_star_msgs);
   NAPI_EXPORT_FUNCTION(dcn_start_threads);

--- a/src/strtable.c
+++ b/src/strtable.c
@@ -24,81 +24,77 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <pthread.h>
+#include <uv.h>
 #include "strtable.h"
 #include <deltachat-ffi/deltachat.h>
 
 
 typedef struct strtable_t {
-	pthread_mutex_t mutex;
-	char*           str[DC_STR_COUNT];
+  uv_mutex_t mutex;
+  char*      str[DC_STR_COUNT];
 } strtable_t;
-
 
 strtable_t* strtable_new()
 {
-	strtable_t* strtable = calloc(1, sizeof(strtable_t));
-	if (strtable==NULL) {
-		exit(666);
-	}
+  strtable_t* strtable = calloc(1, sizeof(strtable_t));
+  if (strtable == NULL) {
+    exit(666);
+  }
 
-	pthread_mutex_init(&strtable->mutex, NULL);
+  uv_mutex_init(&strtable->mutex);
 
-	return strtable;
+  return strtable;
 }
-
 
 void strtable_unref(strtable_t* strtable)
 {
-	if (strtable==NULL) {
-		return;
-	}
+  if (strtable == NULL) {
+    return;
+  }
 
-	for (int i=0; i<DC_STR_COUNT; i++) {
-		free(strtable->str[i]);
-	}
+  for (int i = 0; i < DC_STR_COUNT; i++) {
+    free(strtable->str[i]);
+  }
 
-	pthread_mutex_destroy(&strtable->mutex);
+  uv_mutex_destroy(&strtable->mutex);
 
-	free(strtable);
+  free(strtable);
 }
-
 
 void strtable_set_str(strtable_t* strtable, int i, const char* str)
 {
-	if (strtable==NULL || i<0 || i>=DC_STR_COUNT) {
-		return;
-	}
+  if (strtable == NULL || i < 0 || i >= DC_STR_COUNT) {
+    return;
+  }
 
-	pthread_mutex_lock(&strtable->mutex);
-		free(strtable->str[i]);
-		strtable->str[i] = str? strdup(str) : NULL;
-	pthread_mutex_unlock(&strtable->mutex);
+  uv_mutex_lock(&strtable->mutex);
+    free(strtable->str[i]);
+    strtable->str[i] = str? strdup(str) : NULL;
+  uv_mutex_unlock(&strtable->mutex);
 }
-
 
 char* strtable_get_str(strtable_t* strtable, int i)
 {
-	char* str = NULL;
+  char* str = NULL;
 
-	if (strtable==NULL || i<0 || i>=DC_STR_COUNT) {
-		return NULL;
-	}
+  if (strtable == NULL || i < 0 || i >= DC_STR_COUNT) {
+    return NULL;
+  }
 
-	pthread_mutex_lock(&strtable->mutex);
-		str = strtable->str[i]? strdup(strtable->str[i]) : NULL;
-	pthread_mutex_unlock(&strtable->mutex);
+  uv_mutex_lock(&strtable->mutex);
+    str = strtable->str[i]? strdup(strtable->str[i]) : NULL;
+  uv_mutex_unlock(&strtable->mutex);
 
-	return str;
+  return str;
 }
 
 
 void strtable_clear(strtable_t* strtable)
 {
-	pthread_mutex_lock(&strtable->mutex);
-		for (int i=0; i<DC_STR_COUNT; i++) {
-			free(strtable->str[i]);
-			strtable->str[i] = NULL;
-		}
-	pthread_mutex_unlock(&strtable->mutex);
+  uv_mutex_lock(&strtable->mutex);
+    for (int i=0; i<DC_STR_COUNT; i++) {
+      free(strtable->str[i]);
+      strtable->str[i] = NULL;
+    }
+  uv_mutex_unlock(&strtable->mutex);
 }

--- a/test/index.js
+++ b/test/index.js
@@ -401,15 +401,15 @@ test('ChatList methods', (t, dc) => {
   )
   t.ok(lot.getTimestamp() > 0, 'timestamp set')
 
-  // const text = 'Custom new group message, yo!'
-  // dc.setStringTable(c.DC_STR_NEWGROUPDRAFT, text)
-  // dc.createUnverifiedGroupChat('groupchat1111')
-  // chatList = dc.getChatList(0, 'groupchat1111')
-  // t.is(
-  //   chatList.getSummary(0).getText2(), text,
-  //   'custom new group message'
-  // )
-  // dc.clearStringTable()
+  const text = 'Custom new group message, yo!'
+  dc.setStringTable(c.DC_STR_NEWGROUPDRAFT, text)
+  dc.createUnverifiedGroupChat('groupchat1111')
+  chatList = dc.getChatList(0, 'groupchat1111')
+  t.is(
+    chatList.getSummary(0).getText2(), text,
+    'custom new group message'
+  )
+  dc.clearStringTable()
 
   dc.archiveChat(ids[0], true)
   chatList = dc.getChatList(c.DC_GCL_ARCHIVED_ONLY, 'groupchat1')


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-node/issues/331

I disabled the `strtable` code because windows and pthread. But realized we can probably fix this using `libuv` instead, which pulls in `pthread` for *nix but uses `CRITICAL_SECTION` on windows.