### PR TITLE
chore: add node_modules and deltachat-core-rust/target to appveyor cache

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ install:
   - ps: Install-Product node $env:nodejs_version $env:platform
   - SET PATH=%APPDATA%\npm;%APPVEYOR_BUILD_FOLDER%\node_modules\.bin;%PATH%
   - npm run submodule
-  - mv _target deltachat-core-rust/target
+  - mkdir -p _target && mv _target deltachat-core-rust/target
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv
   - SET PATH=%PATH%;%USERPROFILE%\.cargo\bin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ environment:
     - nodejs_version: "10"
 
 cache:
+  - node_modules
+  - deltachat-core-rust/target
   - C:\Users\appveyor\.rustup
   - C:\Users\appveyor\.cargo
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,10 @@ install:
   - ps: Install-Product node $env:nodejs_version $env:platform
   - SET PATH=%APPDATA%\npm;%APPVEYOR_BUILD_FOLDER%\node_modules\.bin;%PATH%
   - npm run submodule
-  - mkdir -p _target && mv _target deltachat-core-rust/target
+  - ps: >-
+      If (Test-Path -Path _target) {
+        mv _target deltachat-core-rust/target
+      }
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv
   - SET PATH=%PATH%;%USERPROFILE%\.cargo\bin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 
 cache:
   - node_modules
-  - deltachat-core-rust/target
+  - _target
   - C:\Users\appveyor\.rustup
   - C:\Users\appveyor\.cargo
 
@@ -20,6 +20,7 @@ install:
   - ps: Install-Product node $env:nodejs_version $env:platform
   - SET PATH=%APPDATA%\npm;%APPVEYOR_BUILD_FOLDER%\node_modules\.bin;%PATH%
   - npm run submodule
+  - mv _target deltachat-core-rust/target
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv
   - SET PATH=%PATH%;%USERPROFILE%\.cargo\bin
@@ -28,6 +29,7 @@ install:
   - node --version
   - npm --version
   - npm i
+  - mv deltachat-core-rust/target _target
 
 test_script:
   - npm test


### PR DESCRIPTION
This reduces build times on appveyor from 15 minutes down to 3 minutes.

Closes https://github.com/deltachat/deltachat-node/issues/347