### PR TITLE
Link with the dependencies of rust-core

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -38,9 +38,7 @@
                         ],
                         "libraries": [
                             "../deltachat-core-rust/target/release/libdeltachat.a",
-                            "-lm",
                             "-ldl",
-                            "-lrt"
                         ],
                         "conditions": [
                             [ "OS == 'mac'", {
@@ -48,7 +46,13 @@
                                     "-framework CoreFoundation",
                                     "-framework CoreServices",
                                     "-framework Security",
+                                    "-lresolv",
                                 ],
+                            }, { # OS == 'linux'
+                                 "libraries": [
+                                     "-lm",
+                                     "-lrt",
+                                 ]
                             }],
                         ],
                     }, { # system_dc_core == 'true'

--- a/binding.gyp
+++ b/binding.gyp
@@ -37,7 +37,10 @@
                             "deltachat-core-rust",
                         ],
                         "libraries": [
-                            "../deltachat-core-rust/target/release/libdeltachat.a"
+                            "../deltachat-core-rust/target/release/libdeltachat.a",
+                            "-lm",
+                            "-ldl",
+                            "-lrt"
                         ],
                         "conditions": [
                             [ "OS == 'mac'", {


### PR DESCRIPTION
When linking against a static library you must explicitly link against
the dependencies of that static library.  These are the libraries
which rust itself links against to create libdeltachat.so, you can see
this using `readelf -d libdeltachat.so`.  The interesting thing is
that all these libraries are actually part of your libc.  And
depending on which libc and which version of libc you use, some
symbols may be available without extra linking.  So many people would
not have noticed these missing links.  There is no need to try to
detect exactly which links are needed since the loading only happens
lazily anyway, so needlessly linking against a lib which should always
be available anyway is fairly harmless.