### PR TITLE
try moving back deltachat-core/target to _target in on_finish stage

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,6 @@ install:
   - node --version
   - npm --version
   - npm i
-  - mv deltachat-core-rust/target _target
 
 test_script:
   - npm test
@@ -52,3 +51,6 @@ deploy:
     draft: false
     on:
       appveyor_repo_tag: true
+
+on_finish:
+  - mv deltachat-core-rust/target _target

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ environment:
 
 cache:
   - node_modules
-  - _target
   - C:\Users\appveyor\.rustup
   - C:\Users\appveyor\.cargo
 
@@ -20,10 +19,6 @@ install:
   - ps: Install-Product node $env:nodejs_version $env:platform
   - SET PATH=%APPDATA%\npm;%APPVEYOR_BUILD_FOLDER%\node_modules\.bin;%PATH%
   - npm run submodule
-  - ps: >-
-      If (Test-Path -Path _target) {
-        mv _target deltachat-core-rust/target
-      }
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv
   - SET PATH=%PATH%;%USERPROFILE%\.cargo\bin
@@ -51,6 +46,3 @@ deploy:
     draft: false
     on:
       appveyor_repo_tag: true
-
-on_finish:
-  - mv deltachat-core-rust/target _target


### PR DESCRIPTION
First let me explain a little bit about why the caching looks the way it does. We want to cache all built binaries in `deltachat-core-rust/target` folder (for faster builds). The problem with this is that we can't just cache the `deltachat-core-rust/target` as is, because the cache is updated _before_ we clone the `deltachat-core-rust` submodule which causes git to complain.

To get around this we instead cache a `_target` folder which later is moved to `deltachat-core-rust/target` here (after the submodule has been checked out):

https://github.com/deltachat/deltachat-node/blob/6602b5a427b8356c34d119a5afe40a957d958b1b/appveyor.yml#L22-L26

The way we did this messed up building the prebuilt binaries (when pushing a tagged version) since we move away the built `deltachat.dll.lib` which causes the following error

```
LINK : fatal error LNK1181: cannot open input file '..\deltachat-core-rust\target\release\deltachat.dll.lib' [C:\projects\deltachat-node-d4bf8\build\deltachat.vcxproj]
```

https://ci.appveyor.com/project/ralphtheninja/deltachat-node-d4bf8/builds/25677147#L492

This PR attempts to delay the move step (to update the cache) until we're done with the build.

Will leave this PR hanging for a while, since we can only test it fully, once the tests pass, and with a new tag.