### PR TITLE
Upgrade napi-macros

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "debug": "^4.1.1",
     "lodash.pick": "^4.4.0",
     "mkdirp": "^0.5.1",
-    "napi-macros": "^2.0.0",
+    "napi-macros": "^1.7.0",
     "node-gyp-build": "^4.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "debug": "^4.1.1",
     "lodash.pick": "^4.4.0",
     "mkdirp": "^0.5.1",
-    "napi-macros": "^1.7.0",
+    "napi-macros": "^2.0.0",
     "node-gyp-build": "^4.1.0"
   },
   "devDependencies": {

--- a/src/module.c
+++ b/src/module.c
@@ -533,19 +533,19 @@ static void dcn_close_complete(napi_env env, napi_status status, void* data) {
   const int argc = DCN_CLOSE_CALLBACK_ARGC;
   napi_value argv[DCN_CLOSE_CALLBACK_ARGC];
 
-  NAPI_STATUS_THROWS(napi_get_null(env, &argv[0]));
+  napi_get_null(env, &argv[0]);
 
   napi_value global;
-  NAPI_STATUS_THROWS(napi_get_global(env, &global));
+  napi_get_global(env, &global);
   napi_value callback;
-  NAPI_STATUS_THROWS(napi_get_reference_value(env, carrier->callback_ref, &callback));
+  napi_get_reference_value(env, carrier->callback_ref, &callback);
 
   TRACE("calling back to js");
-  NAPI_STATUS_THROWS(napi_call_function(env, global, callback, argc, argv, NULL));
+  napi_call_function(env, global, callback, argc, argv, NULL);
 
   TRACE("cleaning up carrier");
-  NAPI_STATUS_THROWS(napi_delete_reference(env, carrier->callback_ref));
-  NAPI_STATUS_THROWS(napi_delete_async_work(env, carrier->async_work));
+  napi_delete_reference(env, carrier->callback_ref);
+  napi_delete_async_work(env, carrier->async_work);
 
   free(carrier);
   TRACE("done");
@@ -613,7 +613,7 @@ NAPI_ASYNC_COMPLETE(dcn_continue_key_transfer) {
 
   const int argc = DCN_CONTINUE_KEY_TRANSFER_CALLBACK_ARGC;
   napi_value argv[DCN_CONTINUE_KEY_TRANSFER_CALLBACK_ARGC];
-  NAPI_STATUS_THROWS(napi_create_int32(env, carrier->result, &argv[0]));
+  napi_create_int32(env, carrier->result, &argv[0]);
 
   NAPI_ASYNC_CALL_AND_DELETE_CB()
   dc_str_unref(carrier->setup_code);
@@ -1158,9 +1158,9 @@ NAPI_ASYNC_COMPLETE(dcn_initiate_key_transfer) {
   napi_value argv[DCN_INITIATE_KEY_TRANSFER_CALLBACK_ARGC];
 
   if (carrier->result) {
-    NAPI_STATUS_THROWS(napi_create_string_utf8(env, carrier->result, NAPI_AUTO_LENGTH, &argv[0]));
+    napi_create_string_utf8(env, carrier->result, NAPI_AUTO_LENGTH, &argv[0]);
   } else {
-    NAPI_STATUS_THROWS(napi_get_null(env, &argv[0]));
+    napi_get_null(env, &argv[0]);
   }
 
   NAPI_ASYNC_CALL_AND_DELETE_CB();
@@ -1350,22 +1350,22 @@ static void dcn_open_complete(napi_env env, napi_status status, void* data) {
   napi_value argv[DCN_OPEN_COMPLETE_CALLBACK_ARGC];
 
   if (carrier->result == 1) {
-    NAPI_STATUS_THROWS(napi_get_null(env, &argv[0]));
+    napi_get_null(env, &argv[0]);
   } else {
     const char* err_string = "Failed to open";
     napi_value msg;
-    NAPI_STATUS_THROWS(napi_create_string_utf8(env, err_string, strlen(err_string), &msg));
-    NAPI_STATUS_THROWS(napi_create_error(env, NULL, msg, &argv[0]));
+    napi_create_string_utf8(env, err_string, strlen(err_string), &msg);
+    napi_create_error(env, NULL, msg, &argv[0]);
   }
 
   napi_value global;
-  NAPI_STATUS_THROWS(napi_get_global(env, &global));
+  napi_get_global(env, &global);
   napi_value callback;
-  NAPI_STATUS_THROWS(napi_get_reference_value(env, carrier->callback_ref, &callback));
-  NAPI_STATUS_THROWS(napi_call_function(env, global, callback, argc, argv, NULL));
+  napi_get_reference_value(env, carrier->callback_ref, &callback);
+  napi_call_function(env, global, callback, argc, argv, NULL);
 
-  NAPI_STATUS_THROWS(napi_delete_reference(env, carrier->callback_ref));
-  NAPI_STATUS_THROWS(napi_delete_async_work(env, carrier->async_work));
+  napi_delete_reference(env, carrier->callback_ref);
+  napi_delete_async_work(env, carrier->async_work);
 
   free(carrier->dbfile);
   free(carrier->blobdir);

--- a/src/module.c
+++ b/src/module.c
@@ -533,19 +533,19 @@ static void dcn_close_complete(napi_env env, napi_status status, void* data) {
   const int argc = DCN_CLOSE_CALLBACK_ARGC;
   napi_value argv[DCN_CLOSE_CALLBACK_ARGC];
 
-  napi_get_null(env, &argv[0]);
+  NAPI_STATUS_THROWS(napi_get_null(env, &argv[0]));
 
   napi_value global;
-  napi_get_global(env, &global);
+  NAPI_STATUS_THROWS(napi_get_global(env, &global));
   napi_value callback;
-  napi_get_reference_value(env, carrier->callback_ref, &callback);
+  NAPI_STATUS_THROWS(napi_get_reference_value(env, carrier->callback_ref, &callback));
 
   TRACE("calling back to js");
-  napi_call_function(env, global, callback, argc, argv, NULL);
+  NAPI_STATUS_THROWS(napi_call_function(env, global, callback, argc, argv, NULL));
 
   TRACE("cleaning up carrier");
-  napi_delete_reference(env, carrier->callback_ref);
-  napi_delete_async_work(env, carrier->async_work);
+  NAPI_STATUS_THROWS(napi_delete_reference(env, carrier->callback_ref));
+  NAPI_STATUS_THROWS(napi_delete_async_work(env, carrier->async_work));
 
   free(carrier);
   TRACE("done");
@@ -613,7 +613,7 @@ NAPI_ASYNC_COMPLETE(dcn_continue_key_transfer) {
 
   const int argc = DCN_CONTINUE_KEY_TRANSFER_CALLBACK_ARGC;
   napi_value argv[DCN_CONTINUE_KEY_TRANSFER_CALLBACK_ARGC];
-  napi_create_int32(env, carrier->result, &argv[0]);
+  NAPI_STATUS_THROWS(napi_create_int32(env, carrier->result, &argv[0]));
 
   NAPI_ASYNC_CALL_AND_DELETE_CB()
   dc_str_unref(carrier->setup_code);
@@ -1158,9 +1158,9 @@ NAPI_ASYNC_COMPLETE(dcn_initiate_key_transfer) {
   napi_value argv[DCN_INITIATE_KEY_TRANSFER_CALLBACK_ARGC];
 
   if (carrier->result) {
-    napi_create_string_utf8(env, carrier->result, NAPI_AUTO_LENGTH, &argv[0]);
+    NAPI_STATUS_THROWS(napi_create_string_utf8(env, carrier->result, NAPI_AUTO_LENGTH, &argv[0]));
   } else {
-    napi_get_null(env, &argv[0]);
+    NAPI_STATUS_THROWS(napi_get_null(env, &argv[0]));
   }
 
   NAPI_ASYNC_CALL_AND_DELETE_CB();
@@ -1350,22 +1350,22 @@ static void dcn_open_complete(napi_env env, napi_status status, void* data) {
   napi_value argv[DCN_OPEN_COMPLETE_CALLBACK_ARGC];
 
   if (carrier->result == 1) {
-    napi_get_null(env, &argv[0]);
+    NAPI_STATUS_THROWS(napi_get_null(env, &argv[0]));
   } else {
     const char* err_string = "Failed to open";
     napi_value msg;
-    napi_create_string_utf8(env, err_string, strlen(err_string), &msg);
-    napi_create_error(env, NULL, msg, &argv[0]);
+    NAPI_STATUS_THROWS(napi_create_string_utf8(env, err_string, strlen(err_string), &msg));
+    NAPI_STATUS_THROWS(napi_create_error(env, NULL, msg, &argv[0]));
   }
 
   napi_value global;
-  napi_get_global(env, &global);
+  NAPI_STATUS_THROWS(napi_get_global(env, &global));
   napi_value callback;
-  napi_get_reference_value(env, carrier->callback_ref, &callback);
-  napi_call_function(env, global, callback, argc, argv, NULL);
+  NAPI_STATUS_THROWS(napi_get_reference_value(env, carrier->callback_ref, &callback));
+  NAPI_STATUS_THROWS(napi_call_function(env, global, callback, argc, argv, NULL));
 
-  napi_delete_reference(env, carrier->callback_ref);
-  napi_delete_async_work(env, carrier->async_work);
+  NAPI_STATUS_THROWS(napi_delete_reference(env, carrier->callback_ref));
+  NAPI_STATUS_THROWS(napi_delete_async_work(env, carrier->async_work));
 
   free(carrier->dbfile);
   free(carrier->blobdir);

--- a/src/napi-macros-extensions.h
+++ b/src/napi-macros-extensions.h
@@ -66,12 +66,12 @@
 
 #define NAPI_ASYNC_CALL_AND_DELETE_CB() \
   napi_value global; \
-  napi_get_global(env, &global); \
+  NAPI_STATUS_THROWS(napi_get_global(env, &global)); \
   napi_value callback; \
-  napi_get_reference_value(env, carrier->callback_ref, &callback); \
-  napi_call_function(env, global, callback, argc, argv, NULL); \
-  napi_delete_reference(env, carrier->callback_ref); \
-  napi_delete_async_work(env, carrier->async_work);
+  NAPI_STATUS_THROWS(napi_get_reference_value(env, carrier->callback_ref, &callback)); \
+  NAPI_STATUS_THROWS(napi_call_function(env, global, callback, argc, argv, NULL)); \
+  NAPI_STATUS_THROWS(napi_delete_reference(env, carrier->callback_ref)); \
+  NAPI_STATUS_THROWS(napi_delete_async_work(env, carrier->async_work));
 
 #define NAPI_ASYNC_NEW_CARRIER(name) \
   name##_carrier_t* carrier = calloc(1, sizeof(name##_carrier_t)); \

--- a/src/napi-macros-extensions.h
+++ b/src/napi-macros-extensions.h
@@ -1,5 +1,12 @@
 #include <napi-macros.h>
 
+#undef NAPI_STATUS_THROWS
+
+#define NAPI_STATUS_THROWS(call) \
+  if ((call) != napi_ok) { \
+    napi_throw_error(env, NULL, #call " failed!"); \
+  }
+
 #define NAPI_DCN_CONTEXT() \
   dcn_context_t* dcn_context; \
   NAPI_STATUS_THROWS(napi_get_value_external(env, argv[0], (void**)&dcn_context));

--- a/src/napi-macros-extensions.h
+++ b/src/napi-macros-extensions.h
@@ -66,12 +66,12 @@
 
 #define NAPI_ASYNC_CALL_AND_DELETE_CB() \
   napi_value global; \
-  NAPI_STATUS_THROWS(napi_get_global(env, &global)); \
+  napi_get_global(env, &global); \
   napi_value callback; \
-  NAPI_STATUS_THROWS(napi_get_reference_value(env, carrier->callback_ref, &callback)); \
-  NAPI_STATUS_THROWS(napi_call_function(env, global, callback, argc, argv, NULL)); \
-  NAPI_STATUS_THROWS(napi_delete_reference(env, carrier->callback_ref)); \
-  NAPI_STATUS_THROWS(napi_delete_async_work(env, carrier->async_work));
+  napi_get_reference_value(env, carrier->callback_ref, &callback); \
+  napi_call_function(env, global, callback, argc, argv, NULL); \
+  napi_delete_reference(env, carrier->callback_ref); \
+  napi_delete_async_work(env, carrier->async_work);
 
 #define NAPI_ASYNC_NEW_CARRIER(name) \
   name##_carrier_t* carrier = calloc(1, sizeof(name##_carrier_t)); \


### PR DESCRIPTION
`napi-macros@2` introduces a return statement in the `NAPI_STATUS_THROWS()` macro which cause problems for us since we often do cleanup at the end of a function. The easiest fix was simply to remove usage.