### PR TITLE
Enable update of DC configurations

### DIFF
--- a/lib/deltachat.js
+++ b/lib/deltachat.js
@@ -90,10 +90,6 @@ class DeltaChat extends EventEmitter {
       cb && cb()
     }
 
-    if (this.isConfigured()) {
-      return process.nextTick(ready)
-    }
-
     if (typeof opts.addr !== 'string') {
       throw new Error('Missing .addr')
     }


### PR DESCRIPTION
I have no idea why there was a restriction if(dc.isConfigured()) ... return

But obviously it's not possible to update an existing configuration then.

Another issue: after running the integration test with the new updateConfiguration test I see different values in the generated database:
server_flags: 131584
configured_server_flags: 131588
where the first one is correct: 131072 + 512