### PR TITLE
Helper functions to determine chat type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,14 @@ Check if a chat is verified. Corresponds to `dc_chat_is_verified()`.
 
 Check if a chat is a device talk. Corresponds to `dc_chat_is_device_talk()`.
 
+#### `chat.isSingle()`
+
+Check if a chat is a 1-on-1 chat (aka DM).
+
+#### `chat.isGroup()`
+
+Check if a chat is a group chat.
+
 #### `chat.toJson()`
 
 Returns the object state as a JavaScript serializable object.

--- a/lib/chat.ts
+++ b/lib/chat.ts
@@ -2,6 +2,7 @@
 
 const binding = require('../binding')
 const debug = require('debug')('deltachat:node:chat')
+const { C } = require('./constants')
 
 interface NativeChat {}
 /**
@@ -54,6 +55,14 @@ export class Chat {
 
   isDeviceTalk ():boolean {
     return Boolean(binding.dcn_chat_is_device_talk(this.dc_chat))
+  }
+
+  isSingle ():boolean {
+    return this.getType() === C.DC_CHAT_TYPE_SINGLE
+  }
+
+  isGroup ():boolean {
+    return this.getType() === C.DC_CHAT_TYPE_GROUP
   }
 
   toJson () {


### PR DESCRIPTION
Adding two simple helper functions to determine if a chat is 'single' or a 'group'. I found myself repeatedly using DC constants to find the type, which consumers of this API shoudn't have to do, in my opinion. 