### PR TITLE
upload docs to server

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,4 +15,14 @@ jobs:
       run: |
         npm i --ignore-scripts
         npx typedoc
-    # todo upload 
+        mv docs js
+    - name: Upload
+      uses: horochx/deploy-via-scp@v1.0.1
+      with:
+        user: ${{ secrets.USERNAME }}
+        key: ${{ secrets.KEY }}
+        host: "delta.chat"
+        port: 22
+        local: "js"
+        remote: "/var/www/html/"
+

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,6 +1,9 @@
 name: Documentation
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   generate:


### PR DESCRIPTION
Once the username & key are added to the GitHub secrets, this should upload the docs to https://js.delta.chat.

This is based on https://github.com/deltachat/deltachat-node/pull/426