### PR TITLE
generalize include_dirs

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -17,7 +17,7 @@
         "conditions": [
             [ "OS == 'win'", {
                 "include_dirs": [
-                    "deltachat-core-rust",
+                    "deltachat-core-rust/deltachat-ffi",
                 ],
                 "libraries": [
                     "../deltachat-core-rust/target/release/deltachat.dll.lib"
@@ -33,7 +33,7 @@
                 "conditions": [
                     [ "system_dc_core == 'false'", {
                         "include_dirs": [
-                            "deltachat-core-rust",
+                            "deltachat-core-rust/deltachat-ffi",
                         ],
                         "libraries": [
                             "../deltachat-core-rust/target/release/libdeltachat.a",

--- a/src/module.c
+++ b/src/module.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <node_api.h>
 #include <uv.h>
-#include <deltachat-ffi/deltachat.h>
+#include <deltachat.h>
 #include "napi-macros-extensions.h"
 
 #ifdef DEBUG


### PR DESCRIPTION
This allows using a system-wide installation of libdeltachat. Helps with https://github.com/deltachat/deltachat-node/issues/509.

cc @Jikstra 