### PR TITLE
`$SYSTEM_DC_CORE` to use system-wide libdeltachat

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,9 +2,9 @@
     # Variables can be specified when calling node-gyp as so:
     #   node-gyp configure -- -Dvarname=value
     "variables": {
-        # Whether to use a system-wide installation of deltachat-core
-        # using pkg-config.  Set to either "true" or "false".
-        "system_dc_core%": "false"
+        # Whether to use a system-wide installation of libdeltachat using
+        # pkg-config.  Set $SYSTEM_DC_CORE to something non-empty to do so.
+        "system_dc_core%": "<!(echo $SYSTEM_DC_CORE)"
     },
     "targets": [{
         "target_name": "deltachat",
@@ -17,7 +17,7 @@
         "conditions": [
             [ "OS == 'win'", {
                 "include_dirs": [
-                    "deltachat-core-rust",
+                    "deltachat-core-rust/deltachat-ffi",
                 ],
                 "libraries": [
                     "../deltachat-core-rust/target/release/deltachat.dll.lib"
@@ -31,9 +31,9 @@
                     "-std=gnu99",
                 ],
                 "conditions": [
-                    [ "system_dc_core == 'false'", {
+                    [ "system_dc_core == ''", {
                         "include_dirs": [
-                            "deltachat-core-rust",
+                            "deltachat-core-rust/deltachat-ffi",
                         ],
                         "libraries": [
                             "../deltachat-core-rust/target/release/libdeltachat.a",
@@ -54,7 +54,7 @@
                                  ]
                             }],
                         ],
-                    }, { # system_dc_core == 'true'
+                    }, { # "system_dc_core != ''"
                         "cflags": [
                             "<!(pkg-config --cflags deltachat)"
                         ],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "coverage-html-report": "rm -rf coverage/ && nyc report --reporter=html && xdg-open coverage/index.html",
-    "install": "node-gyp-build \"npm run build:core\" \"npm run build:bindings:c:postinstall\" && npm run build:bindings:ts ",
+    "install": "test -z \"$SYSTEM_DC_CORE\" && npm run install:vendored || npm run install:system",
+    "install:system": "npm run build:bindings:c",
+    "install:vendored": "node-gyp-build \"npm run build:core\" \"npm run build:bindings:c:postinstall\" && npm run build:bindings:ts",
     "clean": "rm -rf ./dist ./build ./prebuilds ./deltachat-core-rust/target",
     "build": "npm run build:core && npm run build:bindings",
     "build:core": "npm run build:core:rust && npm run build:core:constants",

--- a/src/module.c
+++ b/src/module.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <node_api.h>
 #include <uv.h>
-#include <deltachat-ffi/deltachat.h>
+#include <deltachat.h>
 #include "napi-macros-extensions.h"
 
 #ifdef DEBUG


### PR DESCRIPTION
I couldn't test this as-is because my setup doesn't allow access to `binding.gyp` during `npm install`. I can confirm that it works if I replace `"install"` with `"build"` in `package.json`.

fixes #509 