### PR TITLE
get rid of dependencies fs-extra and tempy

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '14'
       - name: System info
         run: |
           rustc -vV

--- a/.github/workflows/make-package.yml
+++ b/.github/workflows/make-package.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '14'
       - name: System info
         run: |
           rustc -vV
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '14'
       - name: System info
         run: |
           rustc -vV

--- a/.github/workflows/upload-docs.yaml
+++ b/.github/workflows/upload-docs.yaml
@@ -11,10 +11,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: npm install and generate documentation
       run: |

--- a/lib/deltachat.ts
+++ b/lib/deltachat.ts
@@ -8,12 +8,14 @@ import { ChatList } from './chatlist'
 import { Contact } from './contact'
 import { Message } from './message'
 import { Lot } from './lot'
-import { mkdirp } from 'fs-extra'
+import { mkdtempSync } from 'fs'
+import { mkdir } from 'fs/promises'
 import path from 'path'
 import { Locations } from './locations'
 import pick from 'lodash.pick'
 import rawDebug from 'debug'
-import tempy from 'tempy'
+import { tmpdir } from 'os'
+import { join } from 'path'
 const debug = rawDebug('deltachat:node:index')
 
 const noop = function () {}
@@ -46,7 +48,7 @@ export class DeltaChat extends EventEmitter {
       throw new Error("We're already open!")
     }
 
-    await mkdirp(cwd)
+    await mkdir(cwd, { recursive: true })
 
     const dbFile = path.join(cwd, 'db.sqlite')
 
@@ -587,7 +589,7 @@ export class DeltaChat extends EventEmitter {
 
   static newTempContext() {
     const dcn_context = binding.dcn_context_new(
-      tempy.directory() + '/db.sqlite'
+      join(mkdtempSync(join(tmpdir(), 'deltachat-')), 'db.sqlite')
     )
     return dcn_context
   }

--- a/package.json
+++ b/package.json
@@ -36,18 +36,16 @@
   },
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@types/node": "^13.13.0",
     "debug": "^4.1.1",
-    "fs-extra": "^9.0.1",
     "lodash.pick": "^4.4.0",
     "napi-macros": "^2.0.0",
     "node-fetch": "^2.6.0",
     "node-gyp-build": "^4.1.0",
     "split2": "^3.1.1",
-    "tempy": "^0.3.0",
     "typescript": "^3.7.5"
   },
   "devDependencies": {
+    "@types/node": "^16.4.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "coveralls": "^3.0.3",

--- a/test/test.js
+++ b/test/test.js
@@ -1,13 +1,13 @@
 // @ts-check
 import DeltaChat from '../dist'
-import tempy from 'tempy'
 
 import { strictEqual } from 'assert'
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import { EventId2EventName, C } from '../dist/constants'
 import { join } from 'path'
-import { statSync } from 'fs'
+import { mkdtempSync, statSync } from 'fs'
+import { tmpdir } from 'os'
 chai.use(chaiAsPromised)
 
 describe('static tests', function () {
@@ -64,14 +64,14 @@ describe('static tests', function () {
 describe('Basic offline Tests', function () {
   it('opens a context', async function () {
     const dc = new DeltaChat()
-    await dc.open(tempy.directory())
+    await dc.open(mkTempDir())
     strictEqual(dc.isConfigured(), false)
     dc.close()
   })
 
   it('configure with either missing addr or missing mail_pw throws', async function () {
     const dc = new DeltaChat()
-    await dc.open(tempy.directory())
+    await dc.open(mkTempDir())
 
     await expect(
       dc.configure({ addr: 'delta1@delta.localhost' })
@@ -83,7 +83,7 @@ describe('Basic offline Tests', function () {
 
   it('dc.getInfo()', async function () {
     const dc = new DeltaChat()
-    await dc.open(tempy.directory())
+    await dc.open(mkTempDir())
 
     const info = await dc.getInfo()
     expect(typeof info).to.be.equal('object')
@@ -132,7 +132,7 @@ describe('Offline Tests with unconfigured account', function () {
 
   this.beforeEach(async function () {
     dc = new DeltaChat()
-    directory = tempy.directory()
+    directory = mkTempDir()
     await dc.open(directory)
   })
 
@@ -536,7 +536,7 @@ describe('Integration tests', function () {
 
   this.beforeEach(async function () {
     dc = new DeltaChat()
-    directory = tempy.directory()
+    directory = mkTempDir()
     await dc.open(directory)
   })
 
@@ -691,7 +691,7 @@ describe('Integration tests', function () {
     ).to.be.eventually.fulfilled
     dc.startIO()
     dc2 = new DeltaChat()
-    await dc2.open(tempy.directory())
+    await dc2.open(mkTempDir())
     let setupCode = null
     const waitForSetupCode = waitForSomething()
     const waitForEnd = waitForSomething()
@@ -755,4 +755,11 @@ function waitForSomething() {
     done: resolvePromise,
     promise,
   }
+}
+
+/**
+ * @returns string
+ */
+function mkTempDir() {
+  return mkdtempSync(join(tmpdir(), 'deltachat-'))
 }


### PR DESCRIPTION
Why use dependencies that you'll have to trust if the functionality is built into Node.js?