### PR TITLE
enable strict typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - rename `DeltaChat` to `AccountManager`
 - rename `DeltaChat.accounts()` to `AccountManager.getAllAccountIds()`
 - enable strict typescript
+- update typescript to version `3.9.10`
+- enable typescript declaration map to help IDEs to jump to the ts source files, not the declaration files. 
 
 ## Fixed
 - Fix documentation comment of `AccountManager`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Changed
 - rename `DeltaChat` to `AccountManager`
 - rename `DeltaChat.accounts()` to `AccountManager.getAllAccountIds()`
+- enable strict typescript
 
 ## Fixed
 - Fix documentation comment of `AccountManager`

--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -1,0 +1,9 @@
+import { join } from 'path'
+
+/**
+ * bindings are not typed yet.
+ * if the availible function names are required they can be found inside of `../src/module.c`
+ */
+export const bindings: any = require('node-gyp-build')(join(__dirname, '../'))
+
+export default bindings

--- a/lib/chat.ts
+++ b/lib/chat.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 
-import binding from '../binding'
+import binding from './binding'
 import rawDebug from 'debug'
 const debug = rawDebug('deltachat:node:chat')
 import { C } from './constants'

--- a/lib/chatlist.ts
+++ b/lib/chatlist.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 
-const binding = require('../binding')
+import binding from './binding'
 import { Lot } from './lot'
 import { Chat } from './chat'
 const debug = require('debug')('deltachat:node:chatlist')

--- a/lib/contact.ts
+++ b/lib/contact.ts
@@ -2,7 +2,7 @@ import { integerToHexColor } from './util'
 
 /* eslint-disable camelcase */
 
-const binding = require('../binding')
+import binding from './binding'
 const debug = require('debug')('deltachat:node:contact')
 
 interface NativeContact {}

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,14 +1,12 @@
 /* eslint-disable camelcase */
 
-import binding from '../binding'
-import { C, EventId2EventName } from './constants'
-import { EventEmitter } from 'events'
+import binding from './binding'
+import { C } from './constants'
 import { Chat } from './chat'
 import { ChatList } from './chatlist'
 import { Contact } from './contact'
 import { Message } from './message'
 import { Lot } from './lot'
-import { mkdtempSync } from 'fs'
 import { Locations } from './locations'
 import pick from 'lodash.pick'
 import rawDebug from 'debug'
@@ -36,7 +34,7 @@ export class Context {
 
   unref() {
     binding.dcn_context_unref(this.dcn_context)
-    this.inner_dcn_context = null
+    ;(this.inner_dcn_context as any) = null
   }
 
   acceptChat(chatId: number) {
@@ -124,12 +122,12 @@ export class Context {
         removeListeners()
         resolve()
       }
-      const onFail = (error) => {
+      const onFail = (error: string) => {
         removeListeners()
         reject(new Error(error))
       }
 
-      const onConfigure = (accountId, data1, data2) => {
+      const onConfigure = (accountId: number, data1: number, data2: string) => {
         if (this.account_id !== accountId) {
           return
         }
@@ -164,7 +162,7 @@ export class Context {
         this.dcn_context,
         Number(messageId),
         setupCode,
-        (result) => resolve(result === 1)
+        (result: number) => resolve(result === 1)
       )
     })
   }
@@ -291,7 +289,7 @@ export class Context {
     )
   }
 
-  getChatMessages(chatId: number, flags, marker1before) {
+  getChatMessages(chatId: number, flags: number, marker1before: number) {
     debug(`getChatMessages ${chatId} ${flags} ${marker1before}`)
     return binding.dcn_get_chat_msgs(
       this.dcn_context,
@@ -509,7 +507,7 @@ export class Context {
     binding.dcn_imex(this.dcn_context, what, param1, param2)
   }
 
-  importExportHasBackup(dir) {
+  importExportHasBackup(dir: string) {
     debug(`importExportHasBackup ${dir}`)
     return binding.dcn_imex_has_backup(this.dcn_context, dir)
   }

--- a/lib/deltachat.ts
+++ b/lib/deltachat.ts
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 
-import binding from '../binding'
-import { C, EventId2EventName } from './constants'
+import binding from './binding'
+import { EventId2EventName } from './constants'
 import { EventEmitter } from 'events'
 import { existsSync } from 'fs'
 import rawDebug from 'debug'
@@ -142,7 +142,7 @@ export class AccountManager extends EventEmitter {
 
   static parseGetInfo(info: string) {
     debug('static _getInfo')
-    const result = {}
+    const result: { [key: string]: string } = {}
 
     const regex = /^(\w+)=(.*)$/i
     info
@@ -172,7 +172,7 @@ export class AccountManager extends EventEmitter {
   }
 
   /** get information about the provider
-   * 
+   *
    * This function creates a temporary context to be standalone,
    * if posible use `Context.getProviderFromEmail` instead. (otherwise potential proxy settings are not used)
    * @deprecated

--- a/lib/message.ts
+++ b/lib/message.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 
-import binding from '../binding'
+import binding from './binding'
 import { C } from './constants'
 import { Lot } from './lot'
 import { Chat } from './chat'

--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
     "prebuildify-ci": "^1.0.4",
     "prettier": "^2.0.5",
     "typedoc": "^0.17.0",
-    "typescript": "^3.7.5"
+    "typescript": "^3.9.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "split2": "^3.1.1"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.7",
+    "@types/lodash.pick": "^4.4.6",
     "@types/node": "^14.17.5",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
         "target": "es5",
         "esModuleInterop": true,
         "declaration": true,
+        "declarationMap": true,
         "strictNullChecks": true,
         "strict": true
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,9 @@
         "module": "commonjs",
         "target": "es5",
         "esModuleInterop": true,
-        "declaration": true
+        "declaration": true,
+        "strictNullChecks": true,
+        "strict": true
     },
     "typedocOptions": {
         "mode": "file",


### PR DESCRIPTION
and remove old unused imports

strict typescript enables null checks and require that we specify which variables can be null/undefined and thus make the code safer in preventing some bugs.

~~though this is still WIP until we find a way that we have explicit null also in our outputted declaration files: like that quoted message id can be null. that's needed for strict types in desktop.~~
UPDATE: updateing typescript did the trick.