### PR TITLE
Use int64 to dcn_contact_get_last_seen()

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1877,8 +1877,8 @@ NAPI_METHOD(dcn_contact_get_status) {
 NAPI_METHOD(dcn_contact_get_last_seen) {
   NAPI_ARGV(1);
   NAPI_DC_CONTACT();
-  int timestamp = dc_contact_get_last_seen(dc_contact);
-  NAPI_RETURN_INT32(timestamp);
+  int64_t timestamp = dc_contact_get_last_seen(dc_contact);
+  NAPI_RETURN_INT64(timestamp);
 }
 
 NAPI_METHOD(dcn_contact_is_blocked) {

--- a/src/napi-macros-extensions.h
+++ b/src/napi-macros-extensions.h
@@ -77,6 +77,11 @@
   NAPI_STATUS_THROWS(napi_create_int32(env, name, &return_int32)); \
   return return_int32;
 
+#define NAPI_RETURN_INT64(name) \
+  napi_value return_int64; \
+  NAPI_STATUS_THROWS(napi_create_int64(env, name, &return_int64)); \
+  return return_int64;
+
 
 #define NAPI_RETURN_AND_UNREF_STRING(name) \
   napi_value return_value; \

--- a/test/test.js
+++ b/test/test.js
@@ -467,6 +467,7 @@ describe('Offline Tests with unconfigured account', function () {
     strictEqual(contact.getProfileImage(), null, 'no contact image')
     strictEqual(contact.isBlocked(), false, 'not blocked')
     strictEqual(contact.isVerified(), false, 'unverified status')
+    strictEqual(contact.stats, 0, 'last seen unknown')
   })
 
   it('create contacts from address book', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -467,7 +467,7 @@ describe('Offline Tests with unconfigured account', function () {
     strictEqual(contact.getProfileImage(), null, 'no contact image')
     strictEqual(contact.isBlocked(), false, 'not blocked')
     strictEqual(contact.isVerified(), false, 'unverified status')
-    strictEqual(contact.stats, 0, 'last seen unknown')
+    strictEqual(contact.lastSeen, 0, 'last seen unknown')
   })
 
   it('create contacts from address book', function () {


### PR DESCRIPTION
The int type in c is most likely often a int64, but it's better to enforce it with a type. Plus who knows what that napi method is doing.

closes #531