### PR TITLE
Add -Bsymbolic linker flag to hide sqlite symbols

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -41,6 +41,7 @@
                 "USE_SYSTEM_LIBDELTACHAT != 'true'",
                 {
                   "include_dirs": ["deltachat-core-rust/deltachat-ffi"],
+                  "ldflags": ["-Wl,-Bsymbolic"], # Prevent sqlite3 from electron from overriding sqlcipher
                   "libraries": [
                     "../deltachat-core-rust/target/release/libdeltachat.a",
                     "-ldl",


### PR DESCRIPTION
This prevents electron, which links against SQLite,
from overriding SQLCipher used in libdeltachat during dynamic linking.

Fixes #538