### PR TITLE
fix `Context.setDraft` msg argument type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Fixed
 - fix export backup
+- fix `Context.setDraft(chatId: number, msg: Message | null)` msg argument type to allow for removing drafts
 
 ## [1.75.1] - 2022-02-03
 

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -751,7 +751,7 @@ export class Context {
     )
   }
 
-  setDraft(chatId: number, msg: Message) {
+  setDraft(chatId: number, msg: Message | null) {
     debug(`setDraft ${chatId}`)
     binding.dcn_set_draft(
       this.dcn_context,


### PR DESCRIPTION
to allow for removing drafts
(pass `null` for msg argument)