### PR TITLE
upgrade node version to 16

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
       - name: System info
         run: |
           rustc -vV

--- a/.github/workflows/make-package.yml
+++ b/.github/workflows/make-package.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
       - name: System info
         run: |
           rustc -vV
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
       - name: System info
         run: |
           rustc -vV

--- a/.github/workflows/upload-docs.yaml
+++ b/.github/workflows/upload-docs.yaml
@@ -11,10 +11,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Use Node.js 14.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 16.x
 
     - name: npm install and generate documentation
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased][unreleased]
 
+### BREAKING: we now use node 16
+we now use node version 16.
+Please update if you use an older version! ([`nvm`](https://github.com/nvm-sh/nvm) or [`fnm`](https://github.com/Schniz/fnm) are helpful for this).
+
+### Changed
+- update node version from `14` to `16`
+
 ## [1.77.0] - 2022-04-14
 
 ## Removed

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npm install deltchat-node
 
 ## Dependencies
 
-- Nodejs >= `v14.0.0`
+- Nodejs >= `v16.0.0`
 - rustup (optional if you can't use the prebuilds)
 
 > On Windows, you may need to also install **Perl** to be able to compile deltachat-core.
@@ -61,10 +61,10 @@ building from source or clone this repository and follow this steps:
 deltachat doesn't support universal (fat) binaries (that contain builds for both cpu architectures) yet, until it does you can use the following workaround to get x86_64 builds:
 
 ```
-$ fnm install 14 --arch i386
-$ fnm use 14
+$ fnm install 17 --arch x64
+$ fnm use 17
 $ node -p process.arch
-# result should be i386
+# result should be x64
 $ cd deltachat-core-rust && rustup target add x86_64-apple-darwin && cd -
 $ git apply patches/m1_build_use_x86_64.patch
 $ CARGO_BUILD_TARGET=x86_64-apple-darwin npm run build

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:bindings:c:c": "npx node-gyp rebuild",
     "build:bindings:c:postinstall": "node scripts/postinstall.js",
     "build:bindings:ts": "tsc",
-    "prebuildify": "prebuildify -t 10.16.0 --napi --strip --postinstall \"node scripts/postinstall.js --prebuild\"",
+    "prebuildify": "prebuildify -t 16.13.0 --napi --strip --postinstall \"node scripts/postinstall.js --prebuild\"",
     "download-prebuilds": "prebuildify-ci download",
     "submodule": "git submodule update --recursive --init",
     "test": "npm run test:lint && npm run test:mocha",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/deltachat/deltachat-node.git"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "license": "GPL-3.0-or-later",
   "dependencies": {
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",
-    "@types/node": "^14.17.5",
+    "@types/node": "^16.11.26",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "coveralls": "^3.0.3",

--- a/windows.md
+++ b/windows.md
@@ -6,7 +6,7 @@ E.g via <https://git-scm.com/download/win>
 
 ## install node
 
-Download and install `v14` from <https://nodejs.org/en/>
+Download and install `v16` from <https://nodejs.org/en/>
 
 ## install rust
 


### PR DESCRIPTION
untested with desktop (which would need the same upgrade)
also this could have other side-effects, so maybe rather for the desktop version after the next version

TODO:
- [x] test with desktop
- [x] changelog entry